### PR TITLE
Errors in middleware should not interrupt request processing

### DIFF
--- a/fast_cache_middleware/controller.py
+++ b/fast_cache_middleware/controller.py
@@ -175,7 +175,7 @@ class Controller:
             try:
                 await storage.set(cache_key, response, request, {"ttl": ttl})
             except FastCacheMiddlewareError as e:
-                logger.warning("Failed to cache response: %s", e)
+                logger.error("Failed to cache response: %s", e)
 
         else:
             logger.debug("Skip caching for response: %s", response.status_code)
@@ -196,7 +196,7 @@ class Controller:
         try:
             result = await storage.get(cache_key)
         except FastCacheMiddlewareError as e:
-            logger.warning("Couldn't get the cache: %s", e)
+            logger.error("Couldn't get the cache: %s", e)
             return None
 
         if result is None:

--- a/fast_cache_middleware/controller.py
+++ b/fast_cache_middleware/controller.py
@@ -9,9 +9,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import is_async_callable
 
-from .exceptions import (
-    FastCacheMiddlewareError,
-)
+from .exceptions import FastCacheMiddlewareError
 from .schemas import CacheConfiguration
 from .storages import BaseStorage
 

--- a/fast_cache_middleware/storages/in_memory_storage.py
+++ b/fast_cache_middleware/storages/in_memory_storage.py
@@ -82,7 +82,10 @@ class InMemoryStorage(BaseStorage):
             logger.info("Element %s removed from cache - overwrite", key)
             self._pop_item(key)
 
-        self._storage[key] = (response, request, metadata)
+        try:
+            self._storage[key] = (response, request, metadata)
+        except Exception as e:
+            raise StorageError(e)
 
         data_ttl = metadata.get("ttl", self._ttl)
         if data_ttl is not None:
@@ -114,7 +117,12 @@ class InMemoryStorage(BaseStorage):
 
         self._storage.move_to_end(key)
 
-        return self._storage[key]
+        try:
+            cache = self._storage[key]
+        except Exception as e:
+            raise StorageError(e)
+
+        return cache
 
     async def delete(self, path: re.Pattern) -> None:
         """Removes responses from cache by request path pattern.

--- a/fast_cache_middleware/storages/in_memory_storage.py
+++ b/fast_cache_middleware/storages/in_memory_storage.py
@@ -84,7 +84,7 @@ class InMemoryStorage(BaseStorage):
 
         try:
             self._storage[key] = (response, request, metadata)
-        except Exception as e:
+        except TypeError as e:
             raise StorageError(e)
 
         data_ttl = metadata.get("ttl", self._ttl)
@@ -117,12 +117,7 @@ class InMemoryStorage(BaseStorage):
 
         self._storage.move_to_end(key)
 
-        try:
-            cache = self._storage[key]
-        except Exception as e:
-            raise StorageError(e)
-
-        return cache
+        return self._storage[key]
 
     async def delete(self, path: re.Pattern) -> None:
         """Removes responses from cache by request path pattern.

--- a/fast_cache_middleware/storages/redis_storage.py
+++ b/fast_cache_middleware/storages/redis_storage.py
@@ -64,7 +64,7 @@ class RedisStorage(BaseStorage):
 
         full_key = self._full_key(key)
 
-        if await self._check_exists(full_key):
+        if await self.exists(full_key):
             logger.info("Element %s removed from cache - overwrite", key)
             await self._storage.delete(full_key)
 
@@ -77,7 +77,7 @@ class RedisStorage(BaseStorage):
         """
         full_key = self._full_key(key)
 
-        if not await self._check_exists(full_key):
+        if not await self.exists(full_key):
             raise TTLExpiredStorageError(full_key)
 
         raw_data = await self._storage.get(full_key)
@@ -121,6 +121,3 @@ class RedisStorage(BaseStorage):
 
     def _full_key(self, key: str) -> str:
         return f"{self._namespace}:{key}"
-
-    async def _check_exists(self, key: str) -> int:
-        return await self.exists(key)


### PR DESCRIPTION
close #21 

Воспроизвёл путём НЕ запуска контейнера с Redis:
<img width="1532" height="342" alt="image" src="https://github.com/user-attachments/assets/f5cd0fd1-172e-4031-ab06-f6941434b211" />


Теперь просто пишется всё в лог.