### PR TITLE
Fix delete method in Redis

### DIFF
--- a/tests/storages/test_redis_storage.py
+++ b/tests/storages/test_redis_storage.py
@@ -187,7 +187,7 @@ async def test_remove_with_no_matches_logs_warning() -> None:
 
     pattern = re.compile(r"^/nothing.*")
 
-    async def empty_scan() -> AsyncGenerator[None]:
+    async def empty_scan() -> AsyncGenerator[str, None]:
         if False:
             yield  # type: ignore[unreachable]
         return


### PR DESCRIPTION
close #26

Роуты, которые не имели `key_func` не удалялись через `CacheDropConfig`. Теперь удаляются обе.

<img width="1069" height="252" alt="image" src="https://github.com/user-attachments/assets/9d4d01a8-12e9-4640-888c-f43325c5b9a5" />
